### PR TITLE
Replace deprecated setOutput calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const p = require("phin");
 const core = require("@actions/core");
 const { execSync } = require("child_process");
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 
 // Support Functions
@@ -25,11 +26,11 @@ const addRemote = ({ app_name, dontautocreate, buildpack, region, team, stack })
 
     execSync(
       "heroku create " +
-        app_name +
-        (buildpack ? " --buildpack " + buildpack : "") +
-        (region ? " --region " + region : "") +
-        (stack ? " --stack " + stack : "") +
-        (team ? " --team " + team : "")
+      app_name +
+      (buildpack ? " --buildpack " + buildpack : "") +
+      (region ? " --region " + region : "") +
+      (stack ? " --stack " + stack : "") +
+      (team ? " --team " + team : "")
     );
   }
 };
@@ -159,8 +160,8 @@ if (heroku.appdir) {
     heroku.appdir[0] === "." && heroku.appdir[1] === "/"
       ? heroku.appdir.slice(2)
       : heroku.appdir[0] === "/"
-      ? heroku.appdir.slice(1)
-      : heroku.appdir;
+        ? heroku.appdir.slice(1)
+        : heroku.appdir;
 }
 
 // Collate docker build args into arg list
@@ -242,7 +243,7 @@ if (heroku.dockerBuildArgs) {
         if (res.statusCode !== 200) {
           throw new Error(
             "Status code of network request is not 200: Status code - " +
-              res.statusCode
+            res.statusCode
           );
         }
         if (heroku.checkstring && heroku.checkstring !== res.body.toString()) {
@@ -255,19 +256,21 @@ if (heroku.dockerBuildArgs) {
       }
     }
 
-    core.setOutput(
-      "status",
-      "Successfully deployed heroku app from branch " + heroku.branch
-    );
+    fs.appendFileSync(process.env.GITHUB_OUTPUT,
+      `status=Successfully deployed heroku app from branch ${heroku.branch}`,
+      {
+        encoding: 'utf8'
+      });
   } catch (err) {
     if (
       heroku.dontautocreate &&
       err.toString().includes("Couldn't find that app")
     ) {
-      core.setOutput(
-        "status",
-        "Skipped deploy to heroku app from branch " + heroku.branch
-      );
+      fs.appendFileSync(process.env.GITHUB_OUTPUT,
+        `status=Skipped deploy to heroku app from branch ${heroku.branch}`,
+        {
+          encoding: 'utf8'
+        });
     } else {
       core.setFailed(err.toString());
     }

--- a/scripts/test-action.js
+++ b/scripts/test-action.js
@@ -13,7 +13,11 @@ setTimeout(() => {
         data.GITHUB_REPOSITORY === process.env.GITHUB_REPOSITORY &&
         data.GITHUB_REF === process.env.GITHUB_REF
       ) {
-        core.setOutput("status", "Test Success");
+        fs.appendFileSync(process.env.GITHUB_OUTPUT, 
+          `status="Test Success`, 
+        {
+          encoding: 'utf8'
+        })
       } else {
         core.setFailed("Test Failed: Please check logs to see source of error");
       }


### PR DESCRIPTION
Should fix #156, `setOutput` was [deprecated][1] and will be disabled May 31st, 2023 which will lead to this action breaking or at least no longer outputing whether the deploy failed or succeeded.

I used the following as reference: [GitHub Docs on Workflow Commands][2].

I would have used `process.env.GITHUB_OUTPUT` directly if it weren't for this example provided. Might still be fine to do this but it looks like this is roughly how the `@actions/core` package [does this internally][3].

They [wrap a lot more logic in an internal function][4] that sadly can't (or shouldn't be) imported which is a bit of a bummer considering how simple this operation *should* be. But hey that's Node for ya.

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
[2]: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#sending-values-to-the-pre-and-post-actions
[3]: https://github.com/actions/toolkit/blob/409d616a6e7610097d47caed40057fc21b43da99/packages/core/src/core.ts#L192-L199
[4]: https://github.com/actions/toolkit/blob/409d616a6e7610097d47caed40057fc21b43da99/packages/core/src/file-command.ts#L11-L25